### PR TITLE
Fix md formatting for code in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,9 @@
 
 ## Installing
 Add the following to the head of your website:
-
+```html
 <script type="text/javascript" src="https://cdn.wia.io/sdk/js/v1/wia.min.js"></script>
+```
 
 ## Documentation
 For full documentation visit [http://docs.wia.io/](http://docs.wia.io/)


### PR DESCRIPTION

![screen shot 2017-02-13 at 11 24 55 am](https://cloud.githubusercontent.com/assets/3751990/22872419/19559f4c-f1df-11e6-9345-b2f140ca3b84.png)
`<script>` was not being shown because of bad formatting. This commit fixes that issue.
Fixes #4 
Edit: Adding screenshot.